### PR TITLE
Manifest V3 Migration

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,3 +1,4 @@
+// Taken in large part from Claude 3.7 lmao
 // Taken in large part from short-d/short-ext :)
 const prefix = "bp/";
 const searchProviders = [
@@ -6,44 +7,99 @@ const searchProviders = [
   "duckduckgo.com/",
   "ecosia.org/search",
 ];
-const filter = {
-  urls: [`*://${prefix}*`, ...searchProviders.map((url) => `*://*.${url}*`)],
-  types: ["main_frame"],
-};
 
-function isFromAddressBar(url) {
-  return searchProviders.some((pattern) => url.indexOf(pattern) !== -1);
+// Set up event listener for tab updates to handle search engine queries
+// and direct address bar inputs
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.status === 'loading' && tab.url) {
+    try {
+      // Check if URL is from a search engine
+      if (searchProviders.some(provider => tab.url.includes(provider))) {
+        const url = new URL(tab.url);
+        const searchQuery = url.searchParams.get("q") || url.searchParams.get("p") || url.searchParams.get("query");
+
+        if (searchQuery && searchQuery.includes(prefix)) {
+          // Extract the path after the prefix
+          const path = searchQuery.substring(searchQuery.lastIndexOf(prefix) + prefix.length).trim();
+          const redirectUrl = `https://go.calblueprint.org/?q=${encodeURIComponent(path)}`;
+
+          // Redirect the tab
+          chrome.tabs.update(tabId, { url: redirectUrl });
+        }
+      }
+      // Check for direct "bp/" input in the address bar
+      // This handles cases where the user types bp/something directly
+      else if (tab.url.startsWith(prefix) || tab.url.includes(`://${prefix}`)) {
+        const path = tab.url.substring(tab.url.indexOf(prefix) + prefix.length).trim();
+        const redirectUrl = `https://go.calblueprint.org/?q=${encodeURIComponent(path)}`;
+        chrome.tabs.update(tabId, { url: redirectUrl });
+      }
+    } catch (error) {
+      console.error("Error processing URL:", error);
+    }
+  }
+});
+
+// Set up declarativeNetRequest rules for handling URLs with bp/ format
+async function setupRules() {
+  // Clear existing rules
+  const existingRules = await chrome.declarativeNetRequest.getDynamicRules();
+  await chrome.declarativeNetRequest.updateDynamicRules({
+    removeRuleIds: existingRules.map(rule => rule.id)
+  });
+
+  // Add rules to capture various formats of bp/ URLs
+  await chrome.declarativeNetRequest.updateDynamicRules({
+    addRules: [
+      // Rule for when user types "bp/query" directly in the address bar
+      // Chrome might interpret this as a search if it's not a valid URL
+      {
+        id: 1,
+        priority: 1,
+        action: {
+          type: "redirect",
+          redirect: {
+            url: "https://go.calblueprint.org/?q="
+          }
+        },
+        condition: {
+          urlFilter: "bp/*",
+          resourceTypes: ["main_frame"]
+        }
+      },
+      // Rule for when Chrome prepends "http://" to the bp/ input
+      {
+        id: 2,
+        priority: 1,
+        action: {
+          type: "redirect",
+          redirect: {
+            regexSubstitution: "https://go.calblueprint.org/?q=\\1"
+          }
+        },
+        condition: {
+          regexFilter: "^http://bp/(.*)$",
+          resourceTypes: ["main_frame"]
+        }
+      },
+      // Rule for when Chrome prepends "https://" to the bp/ input
+      {
+        id: 3,
+        priority: 1,
+        action: {
+          type: "redirect",
+          redirect: {
+            regexSubstitution: "https://go.calblueprint.org/?q=\\1"
+          }
+        },
+        condition: {
+          regexFilter: "^https://bp/(.*)$",
+          resourceTypes: ["main_frame"]
+        }
+      }
+    ]
+  });
 }
 
-const userAgent = navigator.userAgent.toLowerCase();
-const isSafari = userAgent.includes("safari") && !userAgent.includes("chrome");
-
-chrome.webRequest.onBeforeRequest.addListener(
-  (details) => {
-    let { url } = details;
-
-    if (isFromAddressBar(url)) {
-      url = new URL(url).searchParams.get("q");
-    }
-    if (url.includes(prefix)) {
-      url = url.substring(url.lastIndexOf(prefix) + prefix.length).trim();
-      const redirectUrl = `https://go.calblueprint.org/?q=${
-        isSafari ? encodeURIComponent(url) : url
-      }`;
-
-      if (isSafari) {
-        chrome.tabs.getCurrent((tab) =>
-          chrome.tabs.update(tab.id, {
-            url: redirectUrl,
-          })
-        );
-      }
-
-      return {
-        redirectUrl,
-      };
-    }
-  },
-  filter,
-  ["blocking"]
-);
+// Initialize the extension
+setupRules().catch(err => console.error("Error setting up rules:", err));

--- a/manifest.json
+++ b/manifest.json
@@ -2,12 +2,12 @@
   "name": "bp/",
   "version": "1.2.2",
   "description": "Shortlinks for Blueprint",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "background": {
-    "scripts": ["background.js"],
-    "persistent": true
+    "service_worker": "background.js"
   },
-  "permissions": ["<all_urls>", "webRequest", "webRequestBlocking", "tabs"],
+  "permissions": ["webRequest", "tabs", "declarativeNetRequest"],
+  "host_permissions": ["<all_urls>"],
   "chrome_settings_overrides": {
     "search_provider": {
       "name": "bp/",


### PR DESCRIPTION
The chrome store now requires all extensions to migrate to the Manifest V3 framework to be on the chrome extension store. I think there are limitations with the new API, so bp/ might flash google before taking you to the actual bp/ page.